### PR TITLE
Use a different layout for each screen size

### DIFF
--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -138,8 +138,7 @@ impl LayoutManager {
             LayoutCommand::MoveFocus(direction) => {
                 let new = self
                     .tree
-                    .selection(layout)
-                    .and_then(|cur| self.tree.traverse(cur, direction))
+                    .traverse(self.tree.selection(layout), direction)
                     .and_then(|new| self.tree.window_at(new));
                 let Some(new) = new else {
                     return EventResponse::default();
@@ -155,29 +154,23 @@ impl LayoutManager {
                 EventResponse::default()
             }
             LayoutCommand::MoveNode(direction) => {
-                if let Some(selection) = self.tree.selection(layout) {
-                    self.tree.move_node(layout, selection, direction);
-                }
+                let selection = self.tree.selection(layout);
+                self.tree.move_node(layout, selection, direction);
                 EventResponse::default()
             }
             LayoutCommand::Split(orientation) => {
-                if let Some(selection) = self.tree.selection(layout) {
-                    self.tree.nest_in_container(layout, selection, LayoutKind::from(orientation));
-                }
+                let selection = self.tree.selection(layout);
+                self.tree.nest_in_container(layout, selection, LayoutKind::from(orientation));
                 EventResponse::default()
             }
             LayoutCommand::Group(orientation) => {
-                if let Some(parent) =
-                    self.tree.selection(layout).and_then(|s| s.parent(self.tree.map()))
-                {
+                if let Some(parent) = self.tree.selection(layout).parent(self.tree.map()) {
                     self.tree.set_layout(parent, LayoutKind::group(orientation));
                 }
                 EventResponse::default()
             }
             LayoutCommand::Ungroup => {
-                if let Some(parent) =
-                    self.tree.selection(layout).and_then(|s| s.parent(self.tree.map()))
-                {
+                if let Some(parent) = self.tree.selection(layout).parent(self.tree.map()) {
                     if self.tree.layout(parent).is_group() {
                         self.tree.set_layout(parent, self.tree.last_ungrouped_layout(parent))
                     }
@@ -235,6 +228,6 @@ impl LayoutManager {
     #[cfg(test)]
     pub(super) fn selected_window(&mut self, space: SpaceId) -> Option<WindowId> {
         let layout = self.layout(space);
-        self.tree.selection(layout).and_then(|node| self.tree.window_at(node))
+        self.tree.window_at(self.tree.selection(layout))
     }
 }

--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -113,14 +113,14 @@ impl LayoutManager {
                 self.tree.set_windows_for_app(layout, pid, windows);
             }
             LayoutEvent::AppClosed(pid) => {
-                self.tree.retain_windows(|w| w.pid != pid);
+                self.tree.remove_windows_for_app(pid);
             }
             LayoutEvent::WindowAdded(space, wid) => {
                 let layout = self.layout(space);
                 self.tree.add_window(layout, self.tree.root(layout), wid);
             }
             LayoutEvent::WindowRemoved(wid) => {
-                self.tree.retain_windows(|&w| w != wid);
+                self.tree.remove_window(wid);
             }
             LayoutEvent::WindowRaised(space, wid) => {
                 if let Some(wid) = wid {

--- a/src/model.rs
+++ b/src/model.rs
@@ -8,4 +8,4 @@ mod tree;
 
 #[allow(unused_imports)]
 pub use layout::{Direction, LayoutKind, Orientation};
-pub use layout_tree::LayoutTree;
+pub use layout_tree::{LayoutId, LayoutTree};

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,6 +5,7 @@ mod layout;
 mod layout_tree;
 mod selection;
 mod tree;
+mod window;
 
 #[allow(unused_imports)]
 pub use layout::{Direction, LayoutKind, Orientation};

--- a/src/model/layout.rs
+++ b/src/model/layout.rs
@@ -269,7 +269,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::{model::LayoutTree, sys::screen::SpaceId};
+    use crate::model::LayoutTree;
 
     fn rect(x: i32, y: i32, w: i32, h: i32) -> CGRect {
         CGRect::new(
@@ -281,16 +281,16 @@ mod tests {
     #[test]
     fn it_lays_out_windows_proportionally() {
         let mut tree = LayoutTree::new();
-        let space = SpaceId::new(1);
-        let root = tree.space(space);
-        let _a1 = tree.add_window(root, WindowId::new(1, 1));
+        let layout = tree.create_layout();
+        let root = tree.root(layout);
+        let _a1 = tree.add_window(layout, root, WindowId::new(1, 1));
         let a2 = tree.add_container(root, LayoutKind::Vertical);
-        let _b1 = tree.add_window(a2, WindowId::new(1, 2));
-        let _b2 = tree.add_window(a2, WindowId::new(1, 3));
-        let _a3 = tree.add_window(root, WindowId::new(1, 4));
+        let _b1 = tree.add_window(layout, a2, WindowId::new(1, 2));
+        let _b2 = tree.add_window(layout, a2, WindowId::new(1, 3));
+        let _a3 = tree.add_window(layout, root, WindowId::new(1, 4));
 
         let screen = rect(0, 0, 3000, 1000);
-        let mut frames = tree.calculate_layout(root, screen);
+        let mut frames = tree.calculate_layout(layout, screen);
         frames.sort_by_key(|&(wid, _)| wid);
         assert_eq!(
             frames,

--- a/src/model/layout.rs
+++ b/src/model/layout.rs
@@ -110,7 +110,7 @@ impl Direction {
 // for the proportionate case, but it feels more like we are distributing the
 // complexity rather than reducing it.
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
 struct LayoutInfo {
     /// The share of the parent's size taken up by this node; 1.0 by default.
     size: f32,
@@ -132,6 +132,9 @@ impl Layout {
                 let parent = node.parent(map).unwrap();
                 self.info[node].size = 1.0;
                 self.info[parent].total += 1.0;
+            }
+            TreeEvent::Copied { src, dest } => {
+                self.info.insert(dest, self.info[src].clone());
             }
             TreeEvent::RemovingFromParent(node) => {
                 self.info[node.parent(map).unwrap()].total -= self.info[node].size;

--- a/src/model/layout_tree.rs
+++ b/src/model/layout_tree.rs
@@ -174,13 +174,12 @@ impl LayoutTree {
         self.tree.data.selection.select(&self.tree.map, selection)
     }
 
-    // TODO: Remove Option
-    pub fn selection(&self, layout: LayoutId) -> Option<NodeId> {
-        Some(self.tree.data.selection.current_selection(self.root(layout)))
+    pub fn selection(&self, layout: LayoutId) -> NodeId {
+        self.tree.data.selection.current_selection(self.root(layout))
     }
 
     pub fn ascend_selection(&mut self, layout: LayoutId) -> bool {
-        if let Some(parent) = self.selection(layout).and_then(|n| n.parent(self.map())) {
+        if let Some(parent) = self.selection(layout).parent(self.map()) {
             self.select(parent);
             return true;
         }
@@ -188,9 +187,8 @@ impl LayoutTree {
     }
 
     pub fn descend_selection(&mut self, layout: LayoutId) -> bool {
-        if let Some(child) = self
-            .selection(layout)
-            .and_then(|n| self.tree.data.selection.last_selection(self.map(), n))
+        if let Some(child) =
+            self.tree.data.selection.last_selection(self.map(), self.selection(layout))
         {
             self.select(child);
             return true;
@@ -711,49 +709,49 @@ mod tests {
         let a3 = tree.add_window(layout, root, WindowId::new(1, 3));
         tree.select(b2);
         tree.assert_children_are([a1, a2, a3], root);
-        assert_eq!(Some(b2), tree.selection(layout));
+        assert_eq!(b2, tree.selection(layout));
 
         tree.move_node(layout, b2, Direction::Left);
         tree.assert_children_are([a1, b2, a2, a3], root);
-        assert_eq!(Some(b2), tree.selection(layout));
+        assert_eq!(b2, tree.selection(layout));
 
         tree.move_node(layout, b2, Direction::Left);
         tree.assert_children_are([b2, a1, a2, a3], root);
-        assert_eq!(Some(b2), tree.selection(layout));
+        assert_eq!(b2, tree.selection(layout));
 
         tree.move_node(layout, a2, Direction::Left);
         tree.assert_children_are([b2, a2, a1, a3], root);
-        assert_eq!(Some(b2), tree.selection(layout));
+        assert_eq!(b2, tree.selection(layout));
 
         tree.select(a3);
         tree.move_node(layout, a3, Direction::Left);
         tree.assert_children_are([b2, a2, a3, a1], root);
-        assert_eq!(Some(a3), tree.selection(layout));
+        assert_eq!(a3, tree.selection(layout));
 
         tree.move_node(layout, a3, Direction::Left);
         tree.assert_children_are([b2, a2, a1], root);
         tree.assert_children_are([b1, b3, a3], a2);
-        assert_eq!(Some(a3), tree.selection(layout));
+        assert_eq!(a3, tree.selection(layout));
 
         tree.move_node(layout, a3, Direction::Right);
         tree.assert_children_are([b2, a2, a3, a1], root);
         tree.assert_children_are([b1, b3], a2);
-        assert_eq!(Some(a3), tree.selection(layout));
+        assert_eq!(a3, tree.selection(layout));
 
         tree.move_node(layout, b1, Direction::Down);
         tree.assert_children_are([b3, b1], a2);
-        assert_eq!(Some(a3), tree.selection(layout));
+        assert_eq!(a3, tree.selection(layout));
 
         tree.move_node(layout, b1, Direction::Up);
         tree.assert_children_are([b1, b3], a2);
-        assert_eq!(Some(a3), tree.selection(layout));
+        assert_eq!(a3, tree.selection(layout));
 
         tree.move_node(layout, b1, Direction::Up);
         let (old_root, root) = (root, tree.root(layout));
         tree.assert_children_are([b1, old_root], root);
         tree.assert_children_are([b2, a2, a3, a1], old_root);
         assert_eq!(LayoutKind::Vertical, tree.layout(root));
-        assert_eq!(Some(a3), tree.selection(layout));
+        assert_eq!(a3, tree.selection(layout));
         assert_eq!(Some(b1), tree.window_node(layout, WindowId::new(2, 1)));
 
         // a2 is culled when its last child moves out of it.
@@ -809,21 +807,21 @@ mod tests {
         );
         tree.assert_children_are([a1, a2], root);
         tree.assert_children_are([b1], a1);
-        assert_eq!(Some(b1), tree.selection(layout));
+        assert_eq!(b1, tree.selection(layout));
 
         tree.select(a2);
         let (b2, a2) = (
             a2,
             tree.nest_in_container(layout, a2, LayoutKind::Horizontal),
         );
-        assert_eq!(Some(b2), tree.selection(layout));
+        assert_eq!(b2, tree.selection(layout));
         tree.assert_children_are([a1, a2], root);
         tree.assert_children_are([b2], a2);
         assert_frames_are(
             orig_frames,
             tree.calculate_layout(layout, rect(0, 0, 1000, 1000)),
         );
-        assert_eq!(Some(b2), tree.selection(layout));
+        assert_eq!(b2, tree.selection(layout));
 
         // Calling on only child updates the (non-root) parent.
         assert_eq!(
@@ -832,7 +830,7 @@ mod tests {
         );
         tree.assert_children_are([a1, a2], root);
         tree.assert_children_are([b2], a2);
-        assert_eq!(Some(b2), tree.selection(layout));
+        assert_eq!(b2, tree.selection(layout));
 
         // Calling on root works too.
         let (old_root, root) = (
@@ -841,11 +839,11 @@ mod tests {
         );
         tree.assert_children_are([old_root], root);
         tree.assert_children_are([a1, a2], old_root);
-        assert_eq!(Some(b2), tree.selection(layout));
+        assert_eq!(b2, tree.selection(layout));
 
         let a3 = tree.add_window(layout, old_root, WindowId::new(1, 3));
         tree.assert_children_are([a1, a2, a3], old_root);
-        assert_eq!(Some(b2), tree.selection(layout));
+        assert_eq!(b2, tree.selection(layout));
     }
 
     #[test]

--- a/src/model/selection.rs
+++ b/src/model/selection.rs
@@ -96,71 +96,74 @@ mod tests {
     use crate::{
         actor::app::WindowId,
         model::{layout::LayoutKind, layout_tree::LayoutTree, Direction},
-        sys::screen::SpaceId,
     };
 
     #[test]
     fn it_moves_as_nodes_are_added_and_removed() {
         let mut tree = LayoutTree::new();
-        let root = tree.space(SpaceId::new(1));
-        let n1 = tree.add_window(root, WindowId::new(1, 1));
-        let n2 = tree.add_window(root, WindowId::new(1, 2));
-        let n3 = tree.add_window(root, WindowId::new(1, 3));
-        assert_eq!(tree.selection(root), Some(root));
+        let layout = tree.create_layout();
+        let root = tree.root(layout);
+        let n1 = tree.add_window(layout, root, WindowId::new(1, 1));
+        let n2 = tree.add_window(layout, root, WindowId::new(1, 2));
+        let n3 = tree.add_window(layout, root, WindowId::new(1, 3));
+        assert_eq!(tree.selection(layout), Some(root));
         tree.select(n2);
-        assert_eq!(tree.selection(root), Some(n2));
+        assert_eq!(tree.selection(layout), Some(n2));
         tree.retain_windows(|&wid| wid != WindowId::new(1, 2));
-        assert_eq!(tree.selection(root), Some(n3));
+        assert_eq!(tree.selection(layout), Some(n3));
         tree.retain_windows(|&wid| wid != WindowId::new(1, 3));
-        assert_eq!(tree.selection(root), Some(n1));
+        assert_eq!(tree.selection(layout), Some(n1));
         tree.retain_windows(|&wid| wid != WindowId::new(1, 1));
-        assert_eq!(tree.selection(root), Some(root));
+        assert_eq!(tree.selection(layout), Some(root));
     }
 
     #[test]
     fn remembers_nested_paths() {
         let mut tree = LayoutTree::new();
-        let root = tree.space(SpaceId::new(1));
-        let a1 = tree.add_window(root, WindowId::new(1, 1));
+        let layout = tree.create_layout();
+        let root = tree.root(layout);
+        let a1 = tree.add_window(layout, root, WindowId::new(1, 1));
         let a2 = tree.add_container(root, LayoutKind::Horizontal);
-        let _b1 = tree.add_window(a2, WindowId::new(1, 2));
-        let b2 = tree.add_window(a2, WindowId::new(1, 3));
-        let _b3 = tree.add_window(a2, WindowId::new(1, 4));
-        let a3 = tree.add_window(root, WindowId::new(1, 5));
+        let _b1 = tree.add_window(layout, a2, WindowId::new(1, 2));
+        let b2 = tree.add_window(layout, a2, WindowId::new(1, 3));
+        let _b3 = tree.add_window(layout, a2, WindowId::new(1, 4));
+        let a3 = tree.add_window(layout, root, WindowId::new(1, 5));
 
         tree.select(b2);
-        assert_eq!(tree.selection(root), Some(b2));
+        assert_eq!(tree.selection(layout), Some(b2));
         tree.select(a1);
-        assert_eq!(tree.selection(root), Some(a1));
+        assert_eq!(tree.selection(layout), Some(a1));
         tree.select(a3);
-        assert_eq!(tree.selection(root), Some(a3));
+        assert_eq!(tree.selection(layout), Some(a3));
         tree.retain_windows(|&wid| wid != WindowId::new(1, 5));
-        assert_eq!(tree.selection(root), Some(b2));
+        assert_eq!(tree.selection(layout), Some(b2));
     }
 
     #[test]
     fn preserves_selection_after_move_within_parent() {
         let mut tree = LayoutTree::new();
-        let root = tree.space(SpaceId::new(1));
-        let _n1 = tree.add_window(root, WindowId::new(1, 1));
-        let n2 = tree.add_window(root, WindowId::new(1, 2));
-        let _n3 = tree.add_window(root, WindowId::new(1, 3));
+        let layout = tree.create_layout();
+        let root = tree.root(layout);
+        let _n1 = tree.add_window(layout, root, WindowId::new(1, 1));
+        let n2 = tree.add_window(layout, root, WindowId::new(1, 2));
+        let _n3 = tree.add_window(layout, root, WindowId::new(1, 3));
         tree.select(n2);
-        assert_eq!(tree.selection(root), Some(n2));
-        tree.move_node(n2, Direction::Left);
-        assert_eq!(tree.selection(root), Some(n2));
+        assert_eq!(tree.selection(layout), Some(n2));
+        tree.move_node(layout, n2, Direction::Left);
+        assert_eq!(tree.selection(layout), Some(n2));
     }
 
     #[test]
     fn allows_parent_selection() {
         let mut tree = LayoutTree::new();
-        let root = tree.space(SpaceId::new(1));
-        let _a1 = tree.add_window(root, WindowId::new(1, 1));
+        let layout = tree.create_layout();
+        let root = tree.root(layout);
+        let _a1 = tree.add_window(layout, root, WindowId::new(1, 1));
         let a2 = tree.add_container(root, LayoutKind::Horizontal);
-        let b1 = tree.add_window(a2, WindowId::new(1, 2));
+        let b1 = tree.add_window(layout, a2, WindowId::new(1, 2));
         tree.select(b1);
-        assert_eq!(tree.selection(root), Some(b1));
+        assert_eq!(tree.selection(layout), Some(b1));
         tree.select(a2);
-        assert_eq!(tree.selection(root), Some(a2));
+        assert_eq!(tree.selection(layout), Some(a2));
     }
 }

--- a/src/model/selection.rs
+++ b/src/model/selection.rs
@@ -106,15 +106,15 @@ mod tests {
         let n1 = tree.add_window(layout, root, WindowId::new(1, 1));
         let n2 = tree.add_window(layout, root, WindowId::new(1, 2));
         let n3 = tree.add_window(layout, root, WindowId::new(1, 3));
-        assert_eq!(tree.selection(layout), Some(root));
+        assert_eq!(tree.selection(layout), root);
         tree.select(n2);
-        assert_eq!(tree.selection(layout), Some(n2));
+        assert_eq!(tree.selection(layout), n2);
         tree.retain_windows(|&wid| wid != WindowId::new(1, 2));
-        assert_eq!(tree.selection(layout), Some(n3));
+        assert_eq!(tree.selection(layout), n3);
         tree.retain_windows(|&wid| wid != WindowId::new(1, 3));
-        assert_eq!(tree.selection(layout), Some(n1));
+        assert_eq!(tree.selection(layout), n1);
         tree.retain_windows(|&wid| wid != WindowId::new(1, 1));
-        assert_eq!(tree.selection(layout), Some(root));
+        assert_eq!(tree.selection(layout), root);
     }
 
     #[test]
@@ -130,13 +130,13 @@ mod tests {
         let a3 = tree.add_window(layout, root, WindowId::new(1, 5));
 
         tree.select(b2);
-        assert_eq!(tree.selection(layout), Some(b2));
+        assert_eq!(tree.selection(layout), b2);
         tree.select(a1);
-        assert_eq!(tree.selection(layout), Some(a1));
+        assert_eq!(tree.selection(layout), a1);
         tree.select(a3);
-        assert_eq!(tree.selection(layout), Some(a3));
+        assert_eq!(tree.selection(layout), a3);
         tree.retain_windows(|&wid| wid != WindowId::new(1, 5));
-        assert_eq!(tree.selection(layout), Some(b2));
+        assert_eq!(tree.selection(layout), b2);
     }
 
     #[test]
@@ -148,9 +148,9 @@ mod tests {
         let n2 = tree.add_window(layout, root, WindowId::new(1, 2));
         let _n3 = tree.add_window(layout, root, WindowId::new(1, 3));
         tree.select(n2);
-        assert_eq!(tree.selection(layout), Some(n2));
+        assert_eq!(tree.selection(layout), n2);
         tree.move_node(layout, n2, Direction::Left);
-        assert_eq!(tree.selection(layout), Some(n2));
+        assert_eq!(tree.selection(layout), n2);
     }
 
     #[test]
@@ -162,8 +162,8 @@ mod tests {
         let a2 = tree.add_container(root, LayoutKind::Horizontal);
         let b1 = tree.add_window(layout, a2, WindowId::new(1, 2));
         tree.select(b1);
-        assert_eq!(tree.selection(layout), Some(b1));
+        assert_eq!(tree.selection(layout), b1);
         tree.select(a2);
-        assert_eq!(tree.selection(layout), Some(a2));
+        assert_eq!(tree.selection(layout), a2);
     }
 }

--- a/src/model/selection.rs
+++ b/src/model/selection.rs
@@ -76,7 +76,7 @@ impl Selection {
         match event {
             AddedToForest(_node) => {}
             AddedToParent(_node) => {}
-            Copied { src, dest } => {
+            Copied { src, dest, .. } => {
                 let Some(info) = self.nodes.get(src) else {
                     return;
                 };
@@ -133,11 +133,11 @@ mod tests {
         assert_eq!(tree.selection(layout), root);
         tree.select(n2);
         assert_eq!(tree.selection(layout), n2);
-        tree.retain_windows(|&wid| wid != WindowId::new(1, 2));
+        tree.remove_window(WindowId::new(1, 2));
         assert_eq!(tree.selection(layout), n3);
-        tree.retain_windows(|&wid| wid != WindowId::new(1, 3));
+        tree.remove_window(WindowId::new(1, 3));
         assert_eq!(tree.selection(layout), n1);
-        tree.retain_windows(|&wid| wid != WindowId::new(1, 1));
+        tree.remove_window(WindowId::new(1, 1));
         assert_eq!(tree.selection(layout), root);
     }
 
@@ -159,7 +159,7 @@ mod tests {
         assert_eq!(tree.selection(layout), a1);
         tree.select(a3);
         assert_eq!(tree.selection(layout), a3);
-        tree.retain_windows(|&wid| wid != WindowId::new(1, 5));
+        tree.remove_window(WindowId::new(1, 5));
         assert_eq!(tree.selection(layout), b2);
     }
 

--- a/src/model/window.rs
+++ b/src/model/window.rs
@@ -1,0 +1,120 @@
+use std::{borrow::Borrow, collections::BTreeMap};
+
+use accessibility_sys::pid_t;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    tree::{NodeId, NodeMap},
+    LayoutId,
+};
+use crate::{actor::app::WindowId, model::layout_tree::TreeEvent};
+
+/// Maintains a two-way mapping between leaf nodes and window ids.
+#[derive(Default, Serialize, Deserialize)]
+pub struct Window {
+    windows: slotmap::SecondaryMap<NodeId, WindowId>,
+    window_nodes: BTreeMap<WindowId, Vec<WindowNodeInfo>>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct WindowNodeInfo {
+    layout: LayoutId,
+    node: NodeId,
+}
+
+impl Window {
+    pub fn at(&self, node: NodeId) -> Option<WindowId> {
+        self.windows.get(node).copied()
+    }
+
+    pub fn node_for(&self, layout: LayoutId, wid: WindowId) -> Option<NodeId> {
+        self.window_nodes
+            .get(&wid)
+            .into_iter()
+            .flat_map(|nodes| nodes.iter().filter(|info| info.layout == layout))
+            .next()
+            .map(|info| info.node)
+    }
+
+    pub fn set_window(&mut self, layout: LayoutId, node: NodeId, wid: WindowId) {
+        let existing = self.windows.insert(node, wid);
+        assert!(
+            existing.is_none(),
+            "Attempted to overwrite window for node {node:?} from {existing:?} to {wid:?}"
+        );
+        self.window_nodes.entry(wid).or_default().push(WindowNodeInfo { layout, node });
+    }
+
+    pub fn set_capacity(&mut self, capacity: usize) {
+        self.windows.set_capacity(capacity);
+        // There's not currently a stable way to do this for BTreeMap.
+    }
+
+    pub(super) fn take_nodes_for(
+        &mut self,
+        wid: WindowId,
+    ) -> impl Iterator<Item = (LayoutId, NodeId)> {
+        self.window_nodes
+            .remove(&wid)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|info| (info.layout, info.node))
+    }
+
+    pub(super) fn take_nodes_for_app(
+        &mut self,
+        pid: pid_t,
+    ) -> impl Iterator<Item = (WindowId, LayoutId, NodeId)> {
+        // There's not currently a stable way to remove only a range, so we have
+        // to do this split/extend dance. Is it faster than scanning through all
+        // the keys? Who knows!
+        #[derive(Ord, PartialOrd, Eq, PartialEq)]
+        #[repr(transparent)]
+        struct PidRange(pid_t);
+        // Technically this violates the Borrow requirements by having Ord/Eq
+        // behave differently than the original type, but we are working around
+        // API limitations and it should not matter for a reasonable implementation
+        // of `split_off`.
+        impl Borrow<PidRange> for WindowId {
+            fn borrow(&self) -> &PidRange {
+                // Safety: PidRange is repr(transparent).
+                unsafe { &*std::ptr::addr_of!(self.pid).cast() }
+            }
+        }
+        let mut split = self.window_nodes.split_off(&PidRange(pid));
+        self.window_nodes.extend(split.split_off(&PidRange(pid + 1)));
+
+        split.into_iter().flat_map(|(wid, infos)| {
+            infos.into_iter().map(move |info| (wid, info.layout, info.node))
+        })
+    }
+
+    pub(super) fn handle_event(&mut self, map: &NodeMap, event: TreeEvent) {
+        use TreeEvent::*;
+        match event {
+            AddedToForest(_) => (),
+            AddedToParent(node) => debug_assert!(
+                self.windows.get(node.parent(map).unwrap()).is_none(),
+                "Window nodes are not allowed to have children: {:?}/{:?}",
+                node.parent(map).unwrap(),
+                node
+            ),
+            Copied { src, dest, dest_layout } => {
+                if let Some(&wid) = self.windows.get(src) {
+                    self.set_window(dest_layout, dest, wid);
+                }
+            }
+            RemovingFromParent(_) => (),
+            RemovedFromForest(node) => {
+                if let Some(wid) = self.windows.remove(node) {
+                    if let Some(window_nodes) = self.window_nodes.get_mut(&wid) {
+                        window_nodes.retain(|info| info.node != node);
+                        if window_nodes.is_empty() {
+                            self.window_nodes.remove(&wid);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Replace SpaceId with LayoutId in LayoutTree API
- Remove Option from TreeLayout::selection return
- Tree::traverse_preorder
- More efficient Tree::traverse_postorder
- Tree::deep_copy
- Use a different layout for each screen size
- model: Move windows into component
