### PR TITLE
Handle raise requests in a queue and never block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
 name = "cc"
 version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +635,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +936,7 @@ dependencies = [
  "test_bin",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1622,6 +1635,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,7 @@ checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
  "bitflags 2.9.1",
  "objc2",
+ "objc2-core-foundation",
  "objc2-foundation",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,22 @@ test-log = { version = "0.2.16", default-features = false, features = [
 ] }
 test_bin = "0.4.0"
 tempfile = { version = "3.17.1", default-features = false }
+objc2-app-kit = { version = "0.3.1", default-features = false, features = [
+    "NSApplication",
+    "NSControl",
+    "NSEvent",
+    "NSFont",
+    "NSGraphics",
+    "NSRunningApplication",
+    "NSResponder",
+    "NSScreen",
+    "NSText",
+    "NSTextField",
+    "NSView",
+    "NSWindow",
+    "NSWorkspace",
+    "objc2-core-foundation",
+] }
 
 [patch.crates-io]
 core-foundation = { git = "https://github.com/tmandry/core-foundation-rs", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,11 @@ objc2-app-kit = { version = "0.3.1", default-features = false, features = [
     "NSWindow",
     "NSWorkspace",
 ] }
-objc2-core-foundation = { version = "0.3.1", features = ["CFCGTypes"] }
+objc2-core-foundation = { version = "0.3.1", features = [
+    "CFCGTypes",
+    "CFRunLoop",
+    "CFDate",
+] }
 objc2-foundation = { version = "0.3.1", default-features = false, features = [
     "NSArray",
     "NSEnumerator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ slotmap = { version = "1.0.7", features = ["serde"] }
 static_assertions = "1.1.0"
 tokio = { version = "1.35.1", features = ["macros", "sync"] }
 tokio-stream = "0.1.16"
+tokio-util = "0.7.15"
 toml = "0.8.20"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/examples/devtool.rs
+++ b/examples/devtool.rs
@@ -217,18 +217,9 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Command::Replay(Replay { path }) => {
-            // We have to spawn a thread because the reactor uses a blocking receive.
-            tokio::task::spawn_blocking(move || {
-                reactor::replay(&path, |_span, request| {
-                    info!(?request);
-                    match request {
-                        nimbus_wm::actor::app::Request::Raise(_, _, Some(ch), _) => _ = ch.send(()),
-                        _ => (),
-                    }
-                })
-            })
-            .await
-            .unwrap()?;
+            reactor::replay(&path, |_span, request| {
+                info!(?request);
+            })?;
         }
         Command::Mouse(Mouse::Clicks) => {
             use core_foundation::runloop::{CFRunLoop, kCFRunLoopCommonModes};

--- a/examples/make_windows.rs
+++ b/examples/make_windows.rs
@@ -1,0 +1,177 @@
+//! Example that creates numbered windows using AppKit and demonstrates the
+//! effect of calling different system APIs on them.
+
+use std::time::Duration;
+
+use accessibility::{AXUIElement, AXUIElementActions, AXUIElementAttributes};
+use nimbus_wm::sys::window_server::{self, WindowServerId};
+use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
+use objc2::{MainThreadMarker, MainThreadOnly, define_class, msg_send};
+use objc2_app_kit::{
+    NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate, NSBackingStoreType,
+    NSFont, NSTextAlignment, NSTextField, NSWindow, NSWindowStyleMask,
+};
+use objc2_foundation::{
+    NSNotification, NSObject, NSObjectProtocol, NSPoint, NSRect, NSSize, NSString,
+};
+
+#[derive(Debug)]
+struct Ivars;
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = Ivars]
+    struct AppDelegate;
+
+    unsafe impl NSObjectProtocol for AppDelegate {}
+
+    unsafe impl NSApplicationDelegate for AppDelegate {
+        #[unsafe(method(applicationDidFinishLaunching:))]
+        fn did_finish_launching(&self, _notification: &NSNotification) {
+            println!("Creating four numbered windows...");
+
+            let mtm = MainThreadMarker::from(self);
+
+            // Create four windows
+            let mut window_numbers = vec![];
+            for i in 1..=4 {
+                println!("Creating window {}", i);
+                let number = create_numbered_window(i, mtm);
+                window_numbers.push(number);
+            }
+
+            println!("All windows created successfully!");
+            println!("The windows should now be visible on your screen.");
+            println!("Press Ctrl+C to quit the application.");
+
+            std::thread::spawn(move || demo(window_numbers));
+        }
+
+        #[unsafe(method(applicationWillTerminate:))]
+        fn will_terminate(&self, _notification: &NSNotification) {
+            println!("Application will terminate!");
+        }
+    }
+);
+
+impl AppDelegate {
+    fn new(mtm: MainThreadMarker) -> Retained<Self> {
+        let this = Self::alloc(mtm);
+        let this = this.set_ivars(Ivars);
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+fn create_numbered_window(number: i32, mtm: MainThreadMarker) -> WindowServerId {
+    // Calculate window position (staggered layout)
+    let x = 100.0 + (number - 1) as f64 * 50.0;
+    let y = 100.0 + (number - 1) as f64 * 50.0;
+    let width = 300.0;
+    let height = 200.0;
+
+    let frame = NSRect {
+        origin: objc2_foundation::NSPoint { x, y },
+        size: NSSize { width, height },
+    };
+
+    // Create window with standard style
+    let style_mask = NSWindowStyleMask::Titled
+        | NSWindowStyleMask::Closable
+        | NSWindowStyleMask::Miniaturizable
+        | NSWindowStyleMask::Resizable;
+
+    let window = unsafe {
+        NSWindow::initWithContentRect_styleMask_backing_defer(
+            NSWindow::alloc(mtm),
+            frame,
+            style_mask,
+            NSBackingStoreType::Buffered,
+            false,
+        )
+    };
+
+    // Set window title
+    let title_string = format!("Window {}", number);
+    let title = NSString::from_str(&title_string);
+    window.setTitle(&title);
+
+    // Create a large text field with the number centered in the window
+    let text_frame = NSRect {
+        origin: NSPoint { x: 0.0, y: height / 2.0 - 50.0 },
+        size: NSSize { width: width, height: 100.0 },
+    };
+
+    // Configure the text field
+    let number_text = NSString::from_str(&number.to_string());
+    let text_field = unsafe {
+        let text_field = NSTextField::labelWithString(&number_text, mtm);
+        text_field.setFrame(text_frame);
+        text_field.setBezeled(false);
+        text_field.setDrawsBackground(false);
+        text_field.setAlignment(NSTextAlignment::Center);
+        text_field.setFont(Some(&*NSFont::systemFontOfSize(72.0)));
+        text_field
+    };
+
+    // Add text field to window's content view
+    if let Some(content_view) = window.contentView() {
+        unsafe {
+            content_view.addSubview(&text_field);
+        }
+    }
+
+    // Make window key and order front
+    window.makeKeyAndOrderFront(None);
+
+    // Don't release when closed (for memory management)
+    unsafe {
+        window.setReleasedWhenClosed(false);
+    }
+    WindowServerId::new(
+        unsafe { window.windowNumber() }.try_into().expect("window number too large"),
+    )
+}
+
+fn demo(window_numbers: Vec<WindowServerId>) {
+    let sleep = |secs| {
+        println!("Sleeping for {secs} seconds");
+        std::thread::sleep(Duration::from_secs(secs))
+    };
+
+    sleep(2);
+
+    let pid = std::process::id() as i32;
+    let wsid = window_numbers[1];
+    let ax_window = AXUIElement::application(pid)
+        .windows()
+        .expect("Could not get AX windows of current process")
+        .iter()
+        .find(|w| WindowServerId::try_from(&**w).ok() == Some(wsid))
+        .expect("Could not find AX window for window #2")
+        .clone();
+
+    println!("Raising #2");
+    ax_window.raise().expect("Raise failed");
+
+    sleep(1);
+
+    println!("Making #2 key window");
+    window_server::make_key_window(pid, wsid).expect("make_key_window failed");
+}
+
+fn main() {
+    let mtm = MainThreadMarker::new().expect("Must run on main thread");
+
+    let app = NSApplication::sharedApplication(mtm);
+    app.setActivationPolicy(NSApplicationActivationPolicy::Regular);
+
+    // Configure the application delegate
+    let delegate = AppDelegate::new(mtm);
+    let object = ProtocolObject::from_ref(&*delegate);
+    app.setDelegate(Some(object));
+
+    // Run the app
+    app.run();
+}

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -8,5 +8,6 @@ pub mod app;
 pub mod layout;
 pub mod mouse;
 pub mod notification_center;
+pub mod raise_manager;
 pub mod reactor;
 pub mod wm_controller;

--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -897,7 +897,7 @@ fn trace<T>(
     let end = Instant::now();
     // FIXME: ?elem here can change system behavior because it sends requests
     // to the app.
-    trace!(time = ?(end - start), ?elem, "{desc:12}");
+    trace!(time = ?(end - start), /*?elem,*/ "{desc:12}");
     if let Err(err) = &out {
         let app = elem.parent();
         debug!("{desc} failed with {err} for element {elem:#?} with parent {app:#?}");

--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -485,7 +485,8 @@ impl State {
         let is_frontmost: bool = trace("is_frontmost", &self.app, || self.app.frontmost())?.into();
 
         // Make this the key window. This ensures that the window has focus and
-        // can receive keyboard events, and activates the app if it isn't already.
+        // can receive keyboard events, and activates the app if it isn't
+        // already. It does nothing to the window order.
         //
         // Note that this uses private APIs. If those stop working we would
         // replace it with NSRunningApplication. We might be able to make
@@ -501,8 +502,9 @@ impl State {
             warn!(?self.pid, "Failed to activate app");
         }
 
-        // Raise the window to be on top. Only does something when the app is
-        // frontmost.
+        // Raise the window to be on top. This only affects the global window
+        // order if the app is already frontmost. Otherwise it affects the
+        // order of windows within that app only.
         let window = self.window(wid)?;
         trace("raise", &window.elem, || window.elem.raise())?;
         drop(mutex_guard);

--- a/src/actor/raise_manager.rs
+++ b/src/actor/raise_manager.rs
@@ -1,0 +1,468 @@
+//! Manages raise requests.
+//!
+//! This actor sits behind the Reactor and is responsible for managing raise requests.
+//! It ensures that windows are raised in the correct order and handles timeouts.
+
+use crate::actor::app::{AppThreadHandle, Quiet, RaiseToken, Request, WindowId};
+use crate::actor::mouse;
+use crate::actor::reactor::{Event, Sender};
+use crate::sys::timer::Timer;
+use objc2_core_foundation::CGPoint;
+use rustc_hash::FxHashMap as HashMap;
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tracing::{Span, debug, info, trace, warn};
+
+/// Messages that can be sent to the raise manager
+#[derive(Debug)]
+pub enum RaiseManagerMessage {
+    ProcessLayoutResponse {
+        raise_windows: Vec<WindowId>,
+        focus_window: Option<(WindowId, Option<CGPoint>)>,
+        app_handles: HashMap<i32, AppThreadHandle>,
+        raise_token: RaiseToken,
+    },
+    RaiseCompleted {
+        window_id: WindowId,
+        sequence_id: u64,
+    },
+    RaiseTimeout {
+        sequence_id: u64,
+    },
+}
+
+/// A synchronous raise manager for testing
+pub struct RaiseManager {
+    /// All the raise requests we are still processing. Note that we keep these
+    /// separate from each other so that the windows are raised in the correct order.
+    pending_sequences: Vec<PendingSequence>,
+    next_sequence_id: u64,
+    mouse_tx: Option<mouse::Sender>,
+}
+
+/// Tracks a pending sequence of raises
+#[derive(Debug)]
+pub struct PendingSequence {
+    sequence_id: u64,
+    pending_raises: HashSet<WindowId>,
+    focus_window: Option<(WindowId, Option<CGPoint>)>,
+    app_handles: HashMap<i32, AppThreadHandle>,
+    raise_token: RaiseToken,
+    started_at: Instant,
+}
+
+const TIMEOUT_DURATION: Duration = Duration::from_millis(250);
+
+impl RaiseManager {
+    /// Run the raise manager task.
+    pub async fn run(
+        mut rx: mpsc::UnboundedReceiver<RaiseManagerMessage>,
+        events_tx: Sender,
+        mouse_tx: Option<mouse::Sender>,
+    ) {
+        let mut raise_manager = RaiseManager::new();
+        raise_manager.mouse_tx = mouse_tx;
+        let mut timeout_timer = Timer::manual();
+
+        loop {
+            // Calculate next timeout timer if we have pending sequences.
+            let timeout = if !raise_manager.pending_sequences.is_empty() {
+                let earliest_elapsed = raise_manager
+                    .pending_sequences
+                    .iter()
+                    .map(|seq| seq.started_at.elapsed())
+                    .max()
+                    .unwrap();
+
+                TIMEOUT_DURATION.saturating_sub(earliest_elapsed)
+            } else {
+                Duration::MAX
+            };
+            timeout_timer.set_next_fire(timeout);
+
+            tokio::select! {
+                // Handle messages from reactor
+                Some(msg) = rx.recv() => {
+                    raise_manager.handle_message(msg);
+                }
+
+                // Handle timeout - send timeout event to reactor
+                _ = timeout_timer.next() => {
+                    // Find the sequence that timed out and send timeout event
+                    for sequence in &raise_manager.pending_sequences {
+                        if sequence.started_at.elapsed() >= TIMEOUT_DURATION {
+                            // Send timeout event to reactor; this will get
+                            // relayed back to us. We send these events through
+                            // the reactor so that we can record/replay them.
+                            let _ = events_tx.send((
+                                tracing::Span::current(),
+                                Event::RaiseTimeout { sequence_id: sequence.sequence_id }
+                            ));
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn new() -> Self {
+        Self {
+            pending_sequences: Vec::new(),
+            next_sequence_id: 1,
+            mouse_tx: None,
+        }
+    }
+
+    fn handle_message(&mut self, msg: RaiseManagerMessage) {
+        match msg {
+            RaiseManagerMessage::ProcessLayoutResponse {
+                raise_windows,
+                focus_window,
+                app_handles,
+                raise_token,
+            } => {
+                debug!(
+                    "Processing layout response with {} raise_windows",
+                    raise_windows.len()
+                );
+
+                let sequence_id = self.next_sequence_id;
+                self.next_sequence_id += 1;
+
+                // Send all raise requests with completion notification
+                let mut pending_raises = HashSet::default();
+
+                for wid in raise_windows {
+                    raise_token.set_pid(wid.pid);
+
+                    if let Some(app_handle) = app_handles.get(&wid.pid) {
+                        if app_handle
+                            .send(Request::Raise(wid, raise_token.clone(), sequence_id, Quiet::Yes))
+                            .is_ok()
+                        {
+                            pending_raises.insert(wid);
+                        }
+                    } else {
+                        // App not found
+                        warn!("App not found for window {:?}", wid);
+                    }
+                }
+
+                if !pending_raises.is_empty() || focus_window.is_some() {
+                    self.pending_sequences.push(PendingSequence {
+                        sequence_id,
+                        pending_raises,
+                        focus_window,
+                        app_handles,
+                        raise_token,
+                        started_at: Instant::now(),
+                    });
+                }
+            }
+            RaiseManagerMessage::RaiseCompleted { window_id, sequence_id } => {
+                trace!("Raise completed for {:?} in sequence {}", window_id, sequence_id);
+
+                // Find the sequence and remove this window from pending
+                if let Some(sequence) =
+                    self.pending_sequences.iter_mut().find(|s| s.sequence_id == sequence_id)
+                {
+                    sequence.pending_raises.remove(&window_id);
+                }
+            }
+            RaiseManagerMessage::RaiseTimeout { sequence_id } => {
+                trace!("Raise sequence {} timed out", sequence_id);
+
+                // Find the sequence and clear all pending raises
+                if let Some(sequence) =
+                    self.pending_sequences.iter_mut().find(|s| s.sequence_id == sequence_id)
+                {
+                    warn!(
+                        "Sequence {} timed out, clearing {} pending raises",
+                        sequence_id,
+                        sequence.pending_raises.len()
+                    );
+                    sequence.pending_raises.clear();
+                }
+            }
+        }
+
+        // Process sequences after handling each message
+        self.process_pending_sequences();
+    }
+
+    /// Process pending sequences, handling completed raises and focus windows
+    pub fn process_pending_sequences(&mut self) {
+        let mut i = 0;
+        // TODO: Use a more idiomatic looping mechanism.
+        while i < self.pending_sequences.len() {
+            let sequence = &mut self.pending_sequences[i];
+
+            // If all raises are complete, process focus window if any.
+            if sequence.pending_raises.is_empty() {
+                if let Some((wid, warp)) = sequence.focus_window {
+                    info!(focus_window = ?wid);
+                    let app_handle = sequence.app_handles.get(&wid.pid);
+                    if let Some(handle) = app_handle {
+                        sequence.raise_token.set_pid(wid.pid);
+
+                        if handle
+                            .send(Request::Raise(
+                                wid,
+                                sequence.raise_token.clone(),
+                                0, // No sequence ID for focus window (FIXME)
+                                Quiet::No,
+                            ))
+                            .is_ok()
+                        {
+                            // FIXME: For focus window, we don't wait for completion
+                            trace!("Focus window request sent");
+                        } else {
+                            warn!("Failed to send focus window request");
+                        }
+
+                        if let Some(warp) = warp {
+                            if let Some(mouse_tx) = &self.mouse_tx {
+                                _ = mouse_tx.send((Span::current(), mouse::Request::Warp(warp)));
+                            }
+                        }
+                    }
+                }
+
+                // Remove completed sequence
+                self.pending_sequences.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actor::app::{AppThreadHandle, RaiseToken, WindowId};
+    use crate::sys::executor::Executor;
+    use std::collections::HashMap;
+    use tokio::sync::mpsc;
+
+    #[test]
+    fn test_raise_manager_handles_layout_response() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+
+            // Create test app handles
+            let mut app_handles = HashMap::default();
+            let (app_tx, _app_rx) = mpsc::unbounded_channel();
+            let app_handle = AppThreadHandle::new_for_test(app_tx);
+            app_handles.insert(1, app_handle);
+
+            // Send a layout response
+            let msg = RaiseManagerMessage::ProcessLayoutResponse {
+                raise_windows: vec![WindowId::new(1, 1), WindowId::new(1, 2)],
+                focus_window: Some((WindowId::new(1, 3), None)),
+                app_handles,
+                raise_token: RaiseToken::default(),
+            };
+
+            // Handle the message synchronously
+            raise_manager.handle_message(msg);
+            // Verify that a pending sequence was created
+            assert_eq!(raise_manager.pending_sequences.len(), 1);
+            let sequence = &raise_manager.pending_sequences[0];
+            assert_eq!(sequence.sequence_id, 1);
+            assert_eq!(sequence.pending_raises.len(), 2);
+            assert!(sequence.focus_window.is_some());
+        });
+    }
+
+    #[test]
+    fn test_raise_completion_removes_pending_window() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+
+            // Create test app handles
+            let mut app_handles = HashMap::default();
+            let (app_tx, _app_rx) = mpsc::unbounded_channel();
+            let app_handle = AppThreadHandle::new_for_test(app_tx);
+            app_handles.insert(1, app_handle);
+
+            // Send a layout response
+            let layout_msg = RaiseManagerMessage::ProcessLayoutResponse {
+                raise_windows: vec![WindowId::new(1, 1), WindowId::new(1, 2)],
+                focus_window: Some((WindowId::new(1, 3), None)),
+                app_handles,
+                raise_token: RaiseToken::default(),
+            };
+
+            raise_manager.handle_message(layout_msg);
+
+            // Verify initial state
+            assert_eq!(raise_manager.pending_sequences.len(), 1);
+            assert_eq!(raise_manager.pending_sequences[0].pending_raises.len(), 2);
+
+            // Send completion for one window
+            let completion_msg = RaiseManagerMessage::RaiseCompleted {
+                window_id: WindowId::new(1, 1),
+                sequence_id: 1,
+            };
+
+            raise_manager.handle_message(completion_msg);
+
+            // Verify that one window was removed from pending
+            assert_eq!(raise_manager.pending_sequences.len(), 1);
+            assert_eq!(raise_manager.pending_sequences[0].pending_raises.len(), 1);
+            assert!(
+                !raise_manager.pending_sequences[0].pending_raises.contains(&WindowId::new(1, 1))
+            );
+            assert!(
+                raise_manager.pending_sequences[0].pending_raises.contains(&WindowId::new(1, 2))
+            );
+        });
+    }
+
+    #[test]
+    fn test_timeout_clears_pending_raises() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+
+            // Create test app handles
+            let mut app_handles = HashMap::default();
+            let (app_tx, _app_rx) = mpsc::unbounded_channel();
+            let app_handle = AppThreadHandle::new_for_test(app_tx);
+            app_handles.insert(1, app_handle);
+
+            // Send a layout response
+            let layout_msg = RaiseManagerMessage::ProcessLayoutResponse {
+                raise_windows: vec![WindowId::new(1, 1)],
+                focus_window: None,
+                app_handles,
+                raise_token: RaiseToken::default(),
+            };
+
+            raise_manager.handle_message(layout_msg);
+
+            // Verify initial state
+            assert_eq!(raise_manager.pending_sequences.len(), 1);
+            assert_eq!(raise_manager.pending_sequences[0].pending_raises.len(), 1);
+
+            // Send timeout directly
+            raise_manager.handle_message(RaiseManagerMessage::RaiseTimeout { sequence_id: 1 });
+
+            // Verify that pending raises were cleared
+            assert_eq!(raise_manager.pending_sequences.len(), 0);
+        });
+    }
+
+    #[test]
+    fn test_all_raises_complete_triggers_focus() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+            let (mouse_tx, mut mouse_rx) = mpsc::unbounded_channel();
+            raise_manager.mouse_tx = Some(mouse_tx);
+
+            // Create test app handles
+            let mut app_handles = HashMap::default();
+            let (app_tx, mut app_rx) = mpsc::unbounded_channel();
+            let app_handle = AppThreadHandle::new_for_test(app_tx);
+            app_handles.insert(1, app_handle);
+
+            // Send a layout response with multiple raises and a focus window
+            let layout_msg = RaiseManagerMessage::ProcessLayoutResponse {
+                raise_windows: vec![WindowId::new(1, 1), WindowId::new(1, 2)],
+                focus_window: Some((WindowId::new(1, 3), Some(CGPoint::new(100.0, 200.0)))),
+                app_handles,
+                raise_token: RaiseToken::default(),
+            };
+
+            raise_manager.handle_message(layout_msg);
+
+            // Verify initial state
+            assert_eq!(raise_manager.pending_sequences.len(), 1);
+            assert_eq!(raise_manager.pending_sequences[0].pending_raises.len(), 2);
+
+            // Send completions for both raise windows
+            raise_manager.handle_message(RaiseManagerMessage::RaiseCompleted {
+                window_id: WindowId::new(1, 1),
+                sequence_id: 1,
+            });
+
+            raise_manager.handle_message(RaiseManagerMessage::RaiseCompleted {
+                window_id: WindowId::new(1, 2),
+                sequence_id: 1,
+            });
+
+            // Verify that the sequence was completed and removed
+            assert_eq!(raise_manager.pending_sequences.len(), 0);
+
+            // Check that focus window request was sent
+            let mut focus_request_found = false;
+            while let Ok((_, request)) = app_rx.try_recv() {
+                if let Request::Raise(wid, _, _, quiet) = request {
+                    if wid == WindowId::new(1, 3) && quiet == Quiet::No {
+                        focus_request_found = true;
+                        break;
+                    }
+                }
+            }
+            assert!(focus_request_found, "Focus window request should have been sent");
+
+            // Check that warp request was sent
+            let warp_request = mouse_rx.try_recv().expect("Warp request should have been sent");
+            let mouse::Request::Warp(warp) = warp_request.1 else {
+                panic!("Unexpected mouse request sent: {:?}", warp_request.1)
+            };
+            assert_eq!(warp, CGPoint::new(100.0, 200.0));
+        });
+    }
+
+    #[test]
+    fn test_timeout_clears_pending_and_triggers_focus() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+
+            // Create test app handles
+            let mut app_handles = HashMap::default();
+            let (app_tx, mut app_rx) = mpsc::unbounded_channel();
+            let app_handle = AppThreadHandle::new_for_test(app_tx);
+            app_handles.insert(1, app_handle);
+
+            // Send a layout response
+            let layout_msg = RaiseManagerMessage::ProcessLayoutResponse {
+                raise_windows: vec![WindowId::new(1, 1), WindowId::new(1, 2)],
+                focus_window: Some((WindowId::new(1, 3), None)),
+                app_handles,
+                raise_token: RaiseToken::default(),
+            };
+
+            raise_manager.handle_message(layout_msg);
+
+            // Verify initial state
+            assert_eq!(raise_manager.pending_sequences.len(), 1);
+            assert_eq!(raise_manager.pending_sequences[0].pending_raises.len(), 2);
+
+            // Send timeout for the sequence
+            raise_manager.handle_message(RaiseManagerMessage::RaiseTimeout { sequence_id: 1 });
+
+            // Verify that the sequence was completed and removed
+            assert_eq!(raise_manager.pending_sequences.len(), 0);
+
+            // Check that focus window request was sent after timeout
+            let mut focus_request_found = false;
+            while let Ok((_, request)) = app_rx.try_recv() {
+                if let Request::Raise(wid, _, _, quiet) = request {
+                    if wid == WindowId::new(1, 3) && quiet == Quiet::No {
+                        focus_request_found = true;
+                        break;
+                    }
+                }
+            }
+
+            assert!(
+                focus_request_found,
+                "Focus window request should have been sent after timeout"
+            );
+        });
+    }
+}

--- a/src/actor/raise_manager.rs
+++ b/src/actor/raise_manager.rs
@@ -4,25 +4,20 @@
 //! It ensures that windows are raised in the correct order and handles timeouts.
 
 use crate::actor::app::{AppThreadHandle, Quiet, RaiseToken, Request, WindowId};
-use crate::actor::mouse;
-use crate::actor::reactor::{Event, Sender};
+use crate::actor::reactor::Sender;
+use crate::actor::{mouse, reactor};
 use crate::sys::timer::Timer;
 use objc2_core_foundation::CGPoint;
 use rustc_hash::FxHashMap as HashMap;
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tracing::{Span, debug, info, trace, warn};
 
 /// Messages that can be sent to the raise manager
 #[derive(Debug)]
-pub enum RaiseManagerMessage {
-    ProcessLayoutResponse {
-        raise_windows: Vec<WindowId>,
-        focus_window: Option<(WindowId, Option<CGPoint>)>,
-        app_handles: HashMap<i32, AppThreadHandle>,
-        raise_token: RaiseToken,
-    },
+pub enum Event {
+    RaiseRequest(RaiseRequest),
     RaiseCompleted {
         window_id: WindowId,
         sequence_id: u64,
@@ -32,18 +27,27 @@ pub enum RaiseManagerMessage {
     },
 }
 
-/// A synchronous raise manager for testing
+/// A queued layout response waiting to be processed.
+#[derive(Debug)]
+pub struct RaiseRequest {
+    pub raise_windows: Vec<WindowId>,
+    pub focus_window: Option<(WindowId, Option<CGPoint>)>,
+    pub app_handles: HashMap<i32, AppThreadHandle>,
+    pub raise_token: RaiseToken,
+}
+
 pub struct RaiseManager {
-    /// All the raise requests we are still processing. Note that we keep these
-    /// separate from each other so that the windows are raised in the correct order.
-    pending_sequences: Vec<PendingSequence>,
+    /// The currently active sequence, if any
+    active_sequence: Option<ActiveSequence>,
+    /// Queued sequences waiting to be processed
+    queued_sequences: VecDeque<RaiseRequest>,
     next_sequence_id: u64,
     mouse_tx: Option<mouse::Sender>,
 }
 
-/// Tracks a pending sequence of raises
+/// Tracks an executing sequence of raises.
 #[derive(Debug)]
-pub struct PendingSequence {
+pub struct ActiveSequence {
     sequence_id: u64,
     pending_raises: HashSet<WindowId>,
     focus_window: Option<(WindowId, Option<CGPoint>)>,
@@ -57,7 +61,7 @@ const TIMEOUT_DURATION: Duration = Duration::from_millis(250);
 impl RaiseManager {
     /// Run the raise manager task.
     pub async fn run(
-        mut rx: mpsc::UnboundedReceiver<RaiseManagerMessage>,
+        mut rx: mpsc::UnboundedReceiver<Event>,
         events_tx: Sender,
         mouse_tx: Option<mouse::Sender>,
     ) {
@@ -66,16 +70,10 @@ impl RaiseManager {
         let mut timeout_timer = Timer::manual();
 
         loop {
-            // Calculate next timeout timer if we have pending sequences.
-            let timeout = if !raise_manager.pending_sequences.is_empty() {
-                let earliest_elapsed = raise_manager
-                    .pending_sequences
-                    .iter()
-                    .map(|seq| seq.started_at.elapsed())
-                    .max()
-                    .unwrap();
-
-                TIMEOUT_DURATION.saturating_sub(earliest_elapsed)
+            // Calculate next timeout timer if we have an active sequence.
+            let timeout = if let Some(sequence) = &raise_manager.active_sequence {
+                let elapsed = sequence.started_at.elapsed();
+                TIMEOUT_DURATION.saturating_sub(elapsed)
             } else {
                 Duration::MAX
             };
@@ -89,17 +87,16 @@ impl RaiseManager {
 
                 // Handle timeout - send timeout event to reactor
                 _ = timeout_timer.next() => {
-                    // Find the sequence that timed out and send timeout event
-                    for sequence in &raise_manager.pending_sequences {
+                    // Send timeout event for the active sequence
+                    if let Some(sequence) = &raise_manager.active_sequence {
                         if sequence.started_at.elapsed() >= TIMEOUT_DURATION {
                             // Send timeout event to reactor; this will get
                             // relayed back to us. We send these events through
                             // the reactor so that we can record/replay them.
                             let _ = events_tx.send((
                                 tracing::Span::current(),
-                                Event::RaiseTimeout { sequence_id: sequence.sequence_id }
+                                reactor::Event::RaiseTimeout { sequence_id: sequence.sequence_id }
                             ));
-                            break;
                         }
                     }
                 }
@@ -109,133 +106,173 @@ impl RaiseManager {
 
     fn new() -> Self {
         Self {
-            pending_sequences: Vec::new(),
+            active_sequence: None,
+            queued_sequences: VecDeque::new(),
             next_sequence_id: 1,
             mouse_tx: None,
         }
     }
 
-    fn handle_message(&mut self, msg: RaiseManagerMessage) {
+    fn handle_message(&mut self, msg: Event) {
         match msg {
-            RaiseManagerMessage::ProcessLayoutResponse {
+            Event::RaiseRequest(RaiseRequest {
                 raise_windows,
                 focus_window,
                 app_handles,
                 raise_token,
-            } => {
+            }) => {
                 debug!(
                     "Processing layout response with {} raise_windows",
                     raise_windows.len()
                 );
 
-                let sequence_id = self.next_sequence_id;
-                self.next_sequence_id += 1;
-
-                // Send all raise requests with completion notification
-                let mut pending_raises = HashSet::default();
-
-                for wid in raise_windows {
-                    raise_token.set_pid(wid.pid);
-
-                    if let Some(app_handle) = app_handles.get(&wid.pid) {
-                        if app_handle
-                            .send(Request::Raise(wid, raise_token.clone(), sequence_id, Quiet::Yes))
-                            .is_ok()
-                        {
-                            pending_raises.insert(wid);
-                        }
-                    } else {
-                        // App not found
-                        warn!("App not found for window {:?}", wid);
-                    }
-                }
-
-                if !pending_raises.is_empty() || focus_window.is_some() {
-                    self.pending_sequences.push(PendingSequence {
-                        sequence_id,
-                        pending_raises,
-                        focus_window,
-                        app_handles,
-                        raise_token,
-                        started_at: Instant::now(),
-                    });
-                }
+                // Always queue the sequence
+                self.queued_sequences.push_back(RaiseRequest {
+                    raise_windows,
+                    focus_window,
+                    app_handles,
+                    raise_token,
+                });
             }
-            RaiseManagerMessage::RaiseCompleted { window_id, sequence_id } => {
+            Event::RaiseCompleted { window_id, sequence_id } => {
                 trace!("Raise completed for {:?} in sequence {}", window_id, sequence_id);
 
-                // Find the sequence and remove this window from pending
-                if let Some(sequence) =
-                    self.pending_sequences.iter_mut().find(|s| s.sequence_id == sequence_id)
-                {
-                    sequence.pending_raises.remove(&window_id);
-                }
-            }
-            RaiseManagerMessage::RaiseTimeout { sequence_id } => {
-                trace!("Raise sequence {} timed out", sequence_id);
-
-                // Find the sequence and clear all pending raises
-                if let Some(sequence) =
-                    self.pending_sequences.iter_mut().find(|s| s.sequence_id == sequence_id)
-                {
-                    warn!(
-                        "Sequence {} timed out, clearing {} pending raises",
-                        sequence_id,
-                        sequence.pending_raises.len()
-                    );
-                    sequence.pending_raises.clear();
-                }
-            }
-        }
-
-        // Process sequences after handling each message
-        self.process_pending_sequences();
-    }
-
-    /// Process pending sequences, handling completed raises and focus windows
-    pub fn process_pending_sequences(&mut self) {
-        let mut i = 0;
-        // TODO: Use a more idiomatic looping mechanism.
-        while i < self.pending_sequences.len() {
-            let sequence = &mut self.pending_sequences[i];
-
-            // If all raises are complete, process focus window if any.
-            if sequence.pending_raises.is_empty() {
-                if let Some((wid, warp)) = sequence.focus_window {
-                    info!(focus_window = ?wid);
-                    let app_handle = sequence.app_handles.get(&wid.pid);
-                    if let Some(handle) = app_handle {
-                        sequence.raise_token.set_pid(wid.pid);
-
-                        if handle
-                            .send(Request::Raise(
-                                wid,
-                                sequence.raise_token.clone(),
-                                0, // No sequence ID for focus window (FIXME)
-                                Quiet::No,
-                            ))
-                            .is_ok()
-                        {
-                            // FIXME: For focus window, we don't wait for completion
-                            trace!("Focus window request sent");
-                        } else {
-                            warn!("Failed to send focus window request");
-                        }
-
-                        if let Some(warp) = warp {
-                            if let Some(mouse_tx) = &self.mouse_tx {
-                                _ = mouse_tx.send((Span::current(), mouse::Request::Warp(warp)));
-                            }
-                        }
+                // Remove this window from the active sequence's pending raises
+                if let Some(sequence) = &mut self.active_sequence {
+                    if sequence.sequence_id == sequence_id {
+                        sequence.pending_raises.remove(&window_id);
                     }
                 }
+            }
+            Event::RaiseTimeout { sequence_id } => {
+                trace!("Raise sequence {} timed out", sequence_id);
 
-                // Remove completed sequence
-                self.pending_sequences.remove(i);
-            } else {
-                i += 1;
+                // Clear pending raises for the active sequence if it matches
+                if let Some(sequence) = &mut self.active_sequence {
+                    if sequence.sequence_id == sequence_id {
+                        warn!(
+                            "Sequence {} timed out, clearing {} pending raises",
+                            sequence_id,
+                            sequence.pending_raises.len()
+                        );
+                        sequence.pending_raises.clear();
+                    }
+                }
             }
         }
+
+        // Process sequences until no more progress can be made (fixed-point iteration)
+        loop {
+            let mut changed = false;
+            changed |= self.process_active_sequence();
+            changed |= self.process_queued_responses();
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    fn process_queued_responses(&mut self) -> bool {
+        if self.active_sequence.is_none() {
+            if let Some(queued) = self.queued_sequences.pop_front() {
+                self.start_new_sequence(queued);
+                return true;
+            }
+        }
+        false
+    }
+
+    fn start_new_sequence(
+        &mut self,
+        RaiseRequest {
+            raise_windows,
+            focus_window,
+            app_handles,
+            raise_token,
+        }: RaiseRequest,
+    ) {
+        let sequence_id = self.next_sequence_id;
+        self.next_sequence_id += 1;
+
+        // Send all raise requests with completion notification
+        let mut pending_raises = HashSet::default();
+
+        for wid in raise_windows {
+            raise_token.set_pid(wid.pid);
+
+            if let Some(app_handle) = app_handles.get(&wid.pid) {
+                if app_handle
+                    .send(Request::Raise(wid, raise_token.clone(), sequence_id, Quiet::Yes))
+                    .is_ok()
+                {
+                    pending_raises.insert(wid);
+                }
+            } else {
+                // App not found
+                warn!("App not found for window {:?}", wid);
+            }
+        }
+
+        if !pending_raises.is_empty() || focus_window.is_some() {
+            self.active_sequence = Some(ActiveSequence {
+                sequence_id,
+                pending_raises,
+                focus_window,
+                app_handles,
+                raise_token,
+                started_at: Instant::now(),
+            });
+        }
+    }
+
+    /// Process the active sequence, handling completed raises and focus windows
+    pub fn process_active_sequence(&mut self) -> bool {
+        let Some(sequence) = &mut self.active_sequence else {
+            return false;
+        };
+        let mut changed = false;
+
+        // If all regular raises are complete but we have a focus window, send
+        // the focus request.
+        if sequence.pending_raises.is_empty() && sequence.focus_window.is_some() {
+            changed = true;
+            let (wid, warp) = sequence.focus_window.take().unwrap();
+            info!(focus_window = ?wid);
+            let app_handle = sequence.app_handles.get(&wid.pid);
+            if let Some(handle) = app_handle {
+                sequence.raise_token.set_pid(wid.pid);
+
+                if handle
+                    .send(Request::Raise(
+                        wid,
+                        sequence.raise_token.clone(),
+                        sequence.sequence_id, // Use proper sequence ID for tracking
+                        Quiet::No,
+                    ))
+                    .is_ok()
+                {
+                    // Add focus window to pending raises so we wait for completion
+                    sequence.pending_raises.insert(wid);
+                    trace!("Focus window request sent and added to pending raises");
+                } else {
+                    warn!("Failed to send focus window request");
+                }
+
+                if let Some(warp) = warp {
+                    if let Some(mouse_tx) = &self.mouse_tx {
+                        _ = mouse_tx.send((Span::current(), mouse::Request::Warp(warp)));
+                    }
+                }
+            }
+        }
+
+        // If all raises (including focus) are complete, remove the active sequence
+        if sequence.pending_raises.is_empty() && sequence.focus_window.is_none() {
+            self.active_sequence = None;
+            changed = true;
+        }
+
+        changed
     }
 }
 
@@ -244,33 +281,82 @@ mod tests {
     use super::*;
     use crate::actor::app::{AppThreadHandle, RaiseToken, WindowId};
     use crate::sys::executor::Executor;
-    use std::collections::HashMap;
     use tokio::sync::mpsc;
+
+    fn create_test_app_handles() -> (
+        HashMap<i32, AppThreadHandle>,
+        mpsc::UnboundedReceiver<(Span, Request)>,
+    ) {
+        let mut app_handles = HashMap::default();
+        let (app_tx, app_rx) = mpsc::unbounded_channel();
+        let app_handle = AppThreadHandle::new_for_test(app_tx);
+        app_handles.insert(1, app_handle);
+        (app_handles, app_rx)
+    }
+
+    fn create_layout_response(
+        raise_windows: Vec<WindowId>,
+        focus_window: Option<(WindowId, Option<CGPoint>)>,
+        app_handles: HashMap<i32, AppThreadHandle>,
+    ) -> Event {
+        Event::RaiseRequest(RaiseRequest {
+            raise_windows,
+            focus_window,
+            app_handles,
+            raise_token: RaiseToken::default(),
+        })
+    }
+
+    fn collect_requests(app_rx: &mut mpsc::UnboundedReceiver<(Span, Request)>) -> Vec<Request> {
+        let mut requests = Vec::new();
+        while let Ok((_, request)) = app_rx.try_recv() {
+            requests.push(request);
+        }
+        requests
+    }
+
+    fn assert_raise_request(
+        request: &Request,
+        expected_wid: WindowId,
+        expected_seq_id: u64,
+        expected_quiet: Quiet,
+    ) {
+        if let Request::Raise(wid, _, seq_id, quiet) = request {
+            assert_eq!(*wid, expected_wid);
+            assert_eq!(*seq_id, expected_seq_id);
+            assert_eq!(*quiet, expected_quiet);
+        } else {
+            panic!("Expected raise request, got: {:?}", request);
+        }
+    }
+
+    fn find_raise_request(requests: &[Request], expected_wid: WindowId) -> bool {
+        requests.iter().any(|r| {
+            if let Request::Raise(wid, _, _, quiet) = r {
+                *wid == expected_wid && *quiet == Quiet::No
+            } else {
+                false
+            }
+        })
+    }
 
     #[test]
     fn test_raise_manager_handles_layout_response() {
         Executor::run(async {
             let mut raise_manager = RaiseManager::new();
+            let (app_handles, _app_rx) = create_test_app_handles();
 
-            // Create test app handles
-            let mut app_handles = HashMap::default();
-            let (app_tx, _app_rx) = mpsc::unbounded_channel();
-            let app_handle = AppThreadHandle::new_for_test(app_tx);
-            app_handles.insert(1, app_handle);
-
-            // Send a layout response
-            let msg = RaiseManagerMessage::ProcessLayoutResponse {
-                raise_windows: vec![WindowId::new(1, 1), WindowId::new(1, 2)],
-                focus_window: Some((WindowId::new(1, 3), None)),
+            let msg = create_layout_response(
+                vec![WindowId::new(1, 1), WindowId::new(1, 2)],
+                Some((WindowId::new(1, 3), None)),
                 app_handles,
-                raise_token: RaiseToken::default(),
-            };
+            );
 
             // Handle the message synchronously
             raise_manager.handle_message(msg);
-            // Verify that a pending sequence was created
-            assert_eq!(raise_manager.pending_sequences.len(), 1);
-            let sequence = &raise_manager.pending_sequences[0];
+            // Verify that an active sequence was created
+            assert!(raise_manager.active_sequence.is_some());
+            let sequence = raise_manager.active_sequence.as_ref().unwrap();
             assert_eq!(sequence.sequence_id, 1);
             assert_eq!(sequence.pending_raises.len(), 2);
             assert!(sequence.focus_window.is_some());
@@ -281,29 +367,25 @@ mod tests {
     fn test_raise_completion_removes_pending_window() {
         Executor::run(async {
             let mut raise_manager = RaiseManager::new();
+            let (app_handles, _app_rx) = create_test_app_handles();
 
-            // Create test app handles
-            let mut app_handles = HashMap::default();
-            let (app_tx, _app_rx) = mpsc::unbounded_channel();
-            let app_handle = AppThreadHandle::new_for_test(app_tx);
-            app_handles.insert(1, app_handle);
-
-            // Send a layout response
-            let layout_msg = RaiseManagerMessage::ProcessLayoutResponse {
-                raise_windows: vec![WindowId::new(1, 1), WindowId::new(1, 2)],
-                focus_window: Some((WindowId::new(1, 3), None)),
+            let layout_msg = create_layout_response(
+                vec![WindowId::new(1, 1), WindowId::new(1, 2)],
+                Some((WindowId::new(1, 3), None)),
                 app_handles,
-                raise_token: RaiseToken::default(),
-            };
+            );
 
             raise_manager.handle_message(layout_msg);
 
             // Verify initial state
-            assert_eq!(raise_manager.pending_sequences.len(), 1);
-            assert_eq!(raise_manager.pending_sequences[0].pending_raises.len(), 2);
+            assert!(raise_manager.active_sequence.is_some());
+            assert_eq!(
+                raise_manager.active_sequence.as_ref().unwrap().pending_raises.len(),
+                2
+            );
 
             // Send completion for one window
-            let completion_msg = RaiseManagerMessage::RaiseCompleted {
+            let completion_msg = Event::RaiseCompleted {
                 window_id: WindowId::new(1, 1),
                 sequence_id: 1,
             };
@@ -311,14 +393,11 @@ mod tests {
             raise_manager.handle_message(completion_msg);
 
             // Verify that one window was removed from pending
-            assert_eq!(raise_manager.pending_sequences.len(), 1);
-            assert_eq!(raise_manager.pending_sequences[0].pending_raises.len(), 1);
-            assert!(
-                !raise_manager.pending_sequences[0].pending_raises.contains(&WindowId::new(1, 1))
-            );
-            assert!(
-                raise_manager.pending_sequences[0].pending_raises.contains(&WindowId::new(1, 2))
-            );
+            assert!(raise_manager.active_sequence.is_some());
+            let sequence = raise_manager.active_sequence.as_ref().unwrap();
+            assert_eq!(sequence.pending_raises.len(), 1);
+            assert!(!sequence.pending_raises.contains(&WindowId::new(1, 1)));
+            assert!(sequence.pending_raises.contains(&WindowId::new(1, 2)));
         });
     }
 
@@ -326,32 +405,24 @@ mod tests {
     fn test_timeout_clears_pending_raises() {
         Executor::run(async {
             let mut raise_manager = RaiseManager::new();
+            let (app_handles, _app_rx) = create_test_app_handles();
 
-            // Create test app handles
-            let mut app_handles = HashMap::default();
-            let (app_tx, _app_rx) = mpsc::unbounded_channel();
-            let app_handle = AppThreadHandle::new_for_test(app_tx);
-            app_handles.insert(1, app_handle);
-
-            // Send a layout response
-            let layout_msg = RaiseManagerMessage::ProcessLayoutResponse {
-                raise_windows: vec![WindowId::new(1, 1)],
-                focus_window: None,
-                app_handles,
-                raise_token: RaiseToken::default(),
-            };
+            let layout_msg = create_layout_response(vec![WindowId::new(1, 1)], None, app_handles);
 
             raise_manager.handle_message(layout_msg);
 
             // Verify initial state
-            assert_eq!(raise_manager.pending_sequences.len(), 1);
-            assert_eq!(raise_manager.pending_sequences[0].pending_raises.len(), 1);
+            assert!(raise_manager.active_sequence.is_some());
+            assert_eq!(
+                raise_manager.active_sequence.as_ref().unwrap().pending_raises.len(),
+                1
+            );
 
             // Send timeout directly
-            raise_manager.handle_message(RaiseManagerMessage::RaiseTimeout { sequence_id: 1 });
+            raise_manager.handle_message(Event::RaiseTimeout { sequence_id: 1 });
 
-            // Verify that pending raises were cleared
-            assert_eq!(raise_manager.pending_sequences.len(), 0);
+            // Verify that the sequence was completed
+            assert!(raise_manager.active_sequence.is_none());
         });
     }
 
@@ -362,51 +433,40 @@ mod tests {
             let (mouse_tx, mut mouse_rx) = mpsc::unbounded_channel();
             raise_manager.mouse_tx = Some(mouse_tx);
 
-            // Create test app handles
-            let mut app_handles = HashMap::default();
-            let (app_tx, mut app_rx) = mpsc::unbounded_channel();
-            let app_handle = AppThreadHandle::new_for_test(app_tx);
-            app_handles.insert(1, app_handle);
+            let (app_handles, mut app_rx) = create_test_app_handles();
 
-            // Send a layout response with multiple raises and a focus window
-            let layout_msg = RaiseManagerMessage::ProcessLayoutResponse {
-                raise_windows: vec![WindowId::new(1, 1), WindowId::new(1, 2)],
-                focus_window: Some((WindowId::new(1, 3), Some(CGPoint::new(100.0, 200.0)))),
+            let layout_msg = create_layout_response(
+                vec![WindowId::new(1, 1), WindowId::new(1, 2)],
+                Some((WindowId::new(1, 3), Some(CGPoint::new(100.0, 200.0)))),
                 app_handles,
-                raise_token: RaiseToken::default(),
-            };
+            );
 
             raise_manager.handle_message(layout_msg);
 
             // Verify initial state
-            assert_eq!(raise_manager.pending_sequences.len(), 1);
-            assert_eq!(raise_manager.pending_sequences[0].pending_raises.len(), 2);
+            assert!(raise_manager.active_sequence.is_some());
+            assert_eq!(
+                raise_manager.active_sequence.as_ref().unwrap().pending_raises.len(),
+                2
+            );
 
             // Send completions for both raise windows
-            raise_manager.handle_message(RaiseManagerMessage::RaiseCompleted {
+            raise_manager.handle_message(Event::RaiseCompleted {
                 window_id: WindowId::new(1, 1),
                 sequence_id: 1,
             });
 
-            raise_manager.handle_message(RaiseManagerMessage::RaiseCompleted {
+            raise_manager.handle_message(Event::RaiseCompleted {
                 window_id: WindowId::new(1, 2),
                 sequence_id: 1,
             });
 
-            // Verify that the sequence was completed and removed
-            assert_eq!(raise_manager.pending_sequences.len(), 0);
-
             // Check that focus window request was sent
-            let mut focus_request_found = false;
-            while let Ok((_, request)) = app_rx.try_recv() {
-                if let Request::Raise(wid, _, _, quiet) = request {
-                    if wid == WindowId::new(1, 3) && quiet == Quiet::No {
-                        focus_request_found = true;
-                        break;
-                    }
-                }
-            }
-            assert!(focus_request_found, "Focus window request should have been sent");
+            let requests = collect_requests(&mut app_rx);
+            assert!(
+                find_raise_request(&requests, WindowId::new(1, 3)),
+                "Focus window request should have been sent"
+            );
 
             // Check that warp request was sent
             let warp_request = mouse_rx.try_recv().expect("Warp request should have been sent");
@@ -414,6 +474,15 @@ mod tests {
                 panic!("Unexpected mouse request sent: {:?}", warp_request.1)
             };
             assert_eq!(warp, CGPoint::new(100.0, 200.0));
+
+            // Complete the focus window raise
+            raise_manager.handle_message(Event::RaiseCompleted {
+                window_id: WindowId::new(1, 3),
+                sequence_id: 1,
+            });
+
+            // Verify that the sequence was completed and removed
+            assert!(raise_manager.active_sequence.is_none());
         });
     }
 
@@ -421,47 +490,223 @@ mod tests {
     fn test_timeout_clears_pending_and_triggers_focus() {
         Executor::run(async {
             let mut raise_manager = RaiseManager::new();
+            let (app_handles, mut app_rx) = create_test_app_handles();
 
-            // Create test app handles
-            let mut app_handles = HashMap::default();
-            let (app_tx, mut app_rx) = mpsc::unbounded_channel();
-            let app_handle = AppThreadHandle::new_for_test(app_tx);
-            app_handles.insert(1, app_handle);
-
-            // Send a layout response
-            let layout_msg = RaiseManagerMessage::ProcessLayoutResponse {
-                raise_windows: vec![WindowId::new(1, 1), WindowId::new(1, 2)],
-                focus_window: Some((WindowId::new(1, 3), None)),
+            let layout_msg = create_layout_response(
+                vec![WindowId::new(1, 1), WindowId::new(1, 2)],
+                Some((WindowId::new(1, 3), None)),
                 app_handles,
-                raise_token: RaiseToken::default(),
-            };
+            );
 
             raise_manager.handle_message(layout_msg);
 
             // Verify initial state
-            assert_eq!(raise_manager.pending_sequences.len(), 1);
-            assert_eq!(raise_manager.pending_sequences[0].pending_raises.len(), 2);
+            assert!(raise_manager.active_sequence.is_some());
+            assert_eq!(
+                raise_manager.active_sequence.as_ref().unwrap().pending_raises.len(),
+                2
+            );
 
             // Send timeout for the sequence
-            raise_manager.handle_message(RaiseManagerMessage::RaiseTimeout { sequence_id: 1 });
-
-            // Verify that the sequence was completed and removed
-            assert_eq!(raise_manager.pending_sequences.len(), 0);
+            raise_manager.handle_message(Event::RaiseTimeout { sequence_id: 1 });
 
             // Check that focus window request was sent after timeout
-            let mut focus_request_found = false;
-            while let Ok((_, request)) = app_rx.try_recv() {
-                if let Request::Raise(wid, _, _, quiet) = request {
-                    if wid == WindowId::new(1, 3) && quiet == Quiet::No {
-                        focus_request_found = true;
-                        break;
-                    }
-                }
-            }
-
+            let requests = collect_requests(&mut app_rx);
             assert!(
-                focus_request_found,
+                find_raise_request(&requests, WindowId::new(1, 3)),
                 "Focus window request should have been sent after timeout"
+            );
+
+            // Complete the focus window raise
+            raise_manager.handle_message(Event::RaiseCompleted {
+                window_id: WindowId::new(1, 3),
+                sequence_id: 1,
+            });
+
+            // Verify that the sequence was completed and removed
+            assert!(raise_manager.active_sequence.is_none());
+        });
+    }
+
+    #[test]
+    fn test_multiple_layout_responses_wait_for_focus_completion() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+            let (app_handles, mut app_rx) = create_test_app_handles();
+
+            // Send two layout responses - second should be queued
+            let msg1 = create_layout_response(
+                vec![WindowId::new(1, 1)],
+                Some((WindowId::new(1, 2), None)),
+                app_handles.clone(),
+            );
+            let msg2 = create_layout_response(
+                vec![WindowId::new(1, 3)],
+                Some((WindowId::new(1, 4), None)),
+                app_handles.clone(),
+            );
+
+            raise_manager.handle_message(msg1);
+            raise_manager.handle_message(msg2);
+
+            // Verify sequential processing: first active, second queued
+            assert!(raise_manager.active_sequence.is_some());
+            assert_eq!(raise_manager.active_sequence.as_ref().unwrap().sequence_id, 1);
+            assert_eq!(raise_manager.queued_sequences.len(), 1);
+
+            // Complete first sequence's regular raise
+            raise_manager.handle_message(Event::RaiseCompleted {
+                window_id: WindowId::new(1, 1),
+                sequence_id: 1,
+            });
+
+            // Verify first sequence now has focus pending, second still queued
+            let sequence = raise_manager.active_sequence.as_ref().unwrap();
+            assert_eq!(sequence.pending_raises.len(), 1);
+            assert!(sequence.pending_raises.contains(&WindowId::new(1, 2)));
+            assert_eq!(raise_manager.queued_sequences.len(), 1);
+
+            // Verify only first sequence requests sent (regular + focus)
+            let requests = collect_requests(&mut app_rx);
+            assert_eq!(requests.len(), 2);
+            assert_raise_request(&requests[0], WindowId::new(1, 1), 1, Quiet::Yes);
+            assert_raise_request(&requests[1], WindowId::new(1, 2), 1, Quiet::No);
+
+            // Complete first sequence's focus window
+            raise_manager.handle_message(Event::RaiseCompleted {
+                window_id: WindowId::new(1, 2),
+                sequence_id: 1,
+            });
+
+            // Verify second sequence now active
+            let sequence = raise_manager.active_sequence.as_ref().unwrap();
+            assert_eq!(sequence.sequence_id, 2);
+            assert_eq!(sequence.pending_raises.len(), 1);
+            assert!(sequence.pending_raises.contains(&WindowId::new(1, 3)));
+            assert_eq!(raise_manager.queued_sequences.len(), 0);
+
+            // Verify second sequence's regular raise sent
+            let requests = collect_requests(&mut app_rx);
+            assert_eq!(requests.len(), 1);
+            assert_raise_request(&requests[0], WindowId::new(1, 3), 2, Quiet::Yes);
+
+            // Complete second sequence's regular raise
+            raise_manager.handle_message(Event::RaiseCompleted {
+                window_id: WindowId::new(1, 3),
+                sequence_id: 2,
+            });
+
+            // Verify second sequence's focus window sent
+            let requests = collect_requests(&mut app_rx);
+            assert_eq!(requests.len(), 1);
+            assert_raise_request(&requests[0], WindowId::new(1, 4), 2, Quiet::No);
+
+            // Complete second sequence's focus window
+            raise_manager.handle_message(Event::RaiseCompleted {
+                window_id: WindowId::new(1, 4),
+                sequence_id: 2,
+            });
+
+            // Verify all sequences completed
+            assert!(raise_manager.active_sequence.is_none());
+            assert!(collect_requests(&mut app_rx).is_empty());
+        });
+    }
+
+    #[test]
+    fn test_multiple_iterations_required_for_chained_completions() {
+        Executor::run(async {
+            let mut raise_manager = RaiseManager::new();
+            let (app_handles, mut app_rx) = create_test_app_handles();
+
+            // Send three layout responses:
+            // 1. First has one regular raise + focus
+            // 2. Second has no regular raises, only focus (will start immediately when first completes)
+            // 3. Third has one regular raise + focus
+            let msg1 = create_layout_response(
+                vec![WindowId::new(1, 1)],
+                Some((WindowId::new(1, 2), None)),
+                app_handles.clone(),
+            );
+            let msg2 = create_layout_response(
+                vec![],
+                Some((WindowId::new(1, 3), None)),
+                app_handles.clone(),
+            );
+            let msg3 = create_layout_response(
+                vec![WindowId::new(1, 4)],
+                Some((WindowId::new(1, 5), None)),
+                app_handles.clone(),
+            );
+
+            // Queue all three sequences
+            raise_manager.handle_message(msg1);
+            raise_manager.handle_message(msg2);
+            raise_manager.handle_message(msg3);
+
+            // Verify first sequence is active, others queued
+            assert!(raise_manager.active_sequence.is_some());
+            assert_eq!(raise_manager.active_sequence.as_ref().unwrap().sequence_id, 1);
+            assert_eq!(raise_manager.queued_sequences.len(), 2);
+
+            // Complete first sequence's regular raise
+            raise_manager.handle_message(Event::RaiseCompleted {
+                window_id: WindowId::new(1, 1),
+                sequence_id: 1,
+            });
+
+            // First sequence should now have focus pending
+            assert!(raise_manager.active_sequence.is_some());
+            assert_eq!(raise_manager.active_sequence.as_ref().unwrap().sequence_id, 1);
+            assert!(
+                raise_manager
+                    .active_sequence
+                    .as_ref()
+                    .unwrap()
+                    .pending_raises
+                    .contains(&WindowId::new(1, 2))
+            );
+
+            // Complete first sequence's focus window - this should trigger multiple iterations:
+            // 1. First sequence completes
+            // 2. Second sequence starts (no regular raises, immediately sends focus)
+            // 3. Focus window is sent and tracked
+            // Without multiple iterations, the second sequence's focus wouldn't be sent
+            raise_manager.handle_message(Event::RaiseCompleted {
+                window_id: WindowId::new(1, 2),
+                sequence_id: 1,
+            });
+
+            // After the completion, we should have:
+            // - Second sequence active with focus window pending
+            // - Third sequence still queued
+            // - Focus request for second sequence should have been sent
+            assert!(raise_manager.active_sequence.is_some());
+            assert_eq!(raise_manager.active_sequence.as_ref().unwrap().sequence_id, 2);
+            assert!(
+                raise_manager
+                    .active_sequence
+                    .as_ref()
+                    .unwrap()
+                    .pending_raises
+                    .contains(&WindowId::new(1, 3))
+            );
+            assert_eq!(raise_manager.queued_sequences.len(), 1);
+
+            // Verify the focus request for second sequence was sent
+            // This would fail with single iteration because the second sequence
+            // wouldn't have a chance to send its focus request
+            let requests = collect_requests(&mut app_rx);
+            let second_focus_sent = requests.iter().any(|r| {
+                if let Request::Raise(wid, _, seq_id, quiet) = r {
+                    *wid == WindowId::new(1, 3) && *seq_id == 2 && *quiet == Quiet::No
+                } else {
+                    false
+                }
+            });
+            assert!(
+                second_focus_sent,
+                "Second sequence's focus request should have been sent immediately after first sequence completed"
             );
         });
     }

--- a/src/actor/reactor/main_window.rs
+++ b/src/actor/reactor/main_window.rs
@@ -82,6 +82,8 @@ impl MainWindowTracker {
             | Event::SpaceChanged(..)
             | Event::MouseUp
             | Event::MouseMovedOverWindow(..)
+            | Event::RaiseCompleted { .. }
+            | Event::RaiseTimeout { .. }
             | Event::Command(..) => return None,
         };
         if Some(event_pid) == self.global_frontmost && quiet_edge == Quiet::No {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -7,4 +7,5 @@ pub mod geometry;
 pub mod observer;
 pub mod run_loop;
 pub mod screen;
+pub mod timer;
 pub mod window_server;

--- a/src/sys/timer.rs
+++ b/src/sys/timer.rs
@@ -1,0 +1,451 @@
+//! Timer functionality using CFRunLoopTimer that integrates with the async executor.
+//!
+//! This module provides async timer functionality that works seamlessly with the
+//! CFRunLoop-based async executor. Timers can be used for delays, timeouts, periodic
+//! tasks, and other time-based operations in async code.
+//!
+//! # Examples
+//!
+//! ## Basic Sleep
+//!
+//! ```rust
+//! use std::time::Duration;
+//! use nimbus_wm::sys::timer::Timer;
+//! use nimbus_wm::sys::executor::Executor;
+//!
+//! Executor::run(async {
+//!     println!("Starting...");
+//!     Timer::sleep(Duration::from_millis(100)).await;
+//!     println!("Done after 100ms!");
+//! });
+//! ```
+//!
+//! ## Timeout Pattern
+//!
+//! ```rust
+//! use std::time::Duration;
+//! use nimbus_wm::sys::timer::Timer;
+//!
+//! async fn with_timeout() {
+//!     let timeout = Timer::sleep(Duration::from_secs(5));
+//!     let operation = some_long_operation();
+//!
+//!     // In real code, you might use tokio::select! or similar
+//!     timeout.await;
+//!     println!("Operation timed out!");
+//! }
+//!
+//! async fn some_long_operation() {
+//!     Timer::sleep(Duration::from_secs(10)).await;
+//! }
+//! ```
+//!
+//! ## Repeating Timer
+//!
+//! ```rust
+//! use std::time::Duration;
+//! use nimbus_wm::sys::timer::Timer;
+//!
+//! async fn monitoring_loop() {
+//!     let mut monitor = Timer::repeating(
+//!         Duration::from_millis(0),   // start immediately
+//!         Duration::from_millis(1000) // check every second
+//!     );
+//!
+//!     let mut check = 1;
+//!     while let Some(_) = monitor.next().await {
+//!         println!("System check #{}", check);
+//!         check += 1;
+//!
+//!         // Early termination based on condition
+//!         if should_stop() {
+//!             monitor.cancel();
+//!         }
+//!     }
+//! }
+//!
+//! fn should_stop() -> bool { false }
+//! ```
+//!
+//! ## Timer Cancellation
+//!
+//! ```rust
+//! use std::time::Duration;
+//! use nimbus_wm::sys::timer::Timer;
+//!
+//! async fn cancellable_operation() {
+//!     let timer = Timer::sleep(Duration::from_secs(10));
+//!
+//!     // Cancel the timer early
+//!     timer.cancel();
+//!
+//!     // This will complete immediately since timer was cancelled
+//!     timer.await;
+//!     println!("Timer was cancelled!");
+//! }
+//! ```
+
+use std::ffi::c_void;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex, Weak};
+use std::task::{Context, Poll, Waker};
+use std::time::Duration;
+
+use objc2_core_foundation::{
+    CFAbsoluteTime, CFAbsoluteTimeGetCurrent, CFRetained, CFRunLoop, CFRunLoopTimer,
+    CFRunLoopTimerContext, CFTimeInterval, kCFAllocatorDefault, kCFRunLoopCommonModes,
+};
+use tokio_stream::Stream;
+
+/// A timer that can be awaited in async code.
+///
+/// This timer integrates with the CFRunLoop-based async executor and provides
+/// a way to schedule delayed execution. Timers are created using either
+/// [`Timer::sleep`] for simple delays or [`Timer::new`] for more control.
+///
+/// # Thread Safety
+///
+/// Timers are installed on the RunLoop of the thread where they are created.
+/// The RunLoop must be running for the timer to fire.
+///
+/// Timers are thread-safe and can be safely shared between threads.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::time::Duration;
+/// use nimbus_wm::sys::timer::Timer;
+///
+/// async fn example() {
+///     // Simple delay
+///     Timer::sleep(Duration::from_millis(100)).await;
+///
+///     // Timer that can be cancelled
+///     let timer = Timer::sleep(Duration::from_secs(5));
+///     timer.cancel(); // Cancel early
+///     timer.await;    // Completes immediately
+/// }
+/// ```
+pub struct Timer {
+    inner: Arc<Mutex<TimerState>>,
+}
+
+struct TimerState {
+    cf_timer: Option<CFRetained<CFRunLoopTimer>>,
+    waker: Option<Waker>,
+    status: TimerStatus,
+}
+
+enum TimerStatus {
+    Pending,
+    Cancelled,
+    Fired,
+}
+
+impl Timer {
+    /// Creates a new timer that will fire after the specified duration.
+    ///
+    /// This is the most common way to create a timer for simple delays.
+    /// The returned `Timer` can be awaited to suspend execution until the timer fires.
+    ///
+    /// # Thread Safety
+    ///
+    /// This method is safe to call from any thread, but the timer will be added
+    /// to the current thread's run loop.
+    pub fn sleep(duration: Duration) -> Self {
+        let fire_time = CFAbsoluteTimeGetCurrent() + duration.as_secs_f64();
+        Self::new(fire_time, 0.0) // 0.0 interval means fire once
+    }
+
+    /// Creates a repeating timer that fires at regular intervals.
+    ///
+    /// This creates a CFRunLoopTimer with a repeat interval. You can await the timer
+    /// multiple times with the convenience method `timer.next().await`.
+    ///
+    /// # Arguments
+    ///
+    /// * `initial_delay` - How long to wait before the first fire
+    /// * `interval` - The repeat interval
+    pub fn repeating(initial_delay: Duration, interval: Duration) -> Self {
+        let fire_time = CFAbsoluteTimeGetCurrent() + initial_delay.as_secs_f64();
+        Self::new(fire_time, interval.as_secs_f64())
+    }
+
+    /// Creates a repeating timer that can be controlled with `set_next_fire`.
+    ///
+    /// This is much cheaper than creating a new timer every time you want to
+    /// set a new fire time.
+    pub fn manual() -> Self {
+        // Make a repeating timer with a very long duration. This is recommended in the Apple docs:
+        // https://developer.apple.com/documentation/corefoundation/cfrunlooptimersetnextfiredate(_:_:)
+        Self::repeating(Duration::MAX, Duration::MAX)
+    }
+
+    /// Creates a new timer that fires at the specified absolute time.
+    ///
+    /// This is a lower-level method for creating timers with precise timing control.
+    /// For simple delays, prefer [`Timer::sleep`] instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `fire_date` - The absolute time when the timer should fire (CFAbsoluteTime)
+    /// * `interval` - The repeat interval in seconds (0.0 for one-shot timer)
+    pub fn new(fire_date: CFAbsoluteTime, interval: CFTimeInterval) -> Self {
+        let inner = Arc::new(Mutex::new(TimerState {
+            cf_timer: None,
+            waker: None,
+            status: TimerStatus::Pending,
+        }));
+
+        // We use a Weak reference to avoid circular references
+        let timer_ref = Arc::downgrade(&inner);
+
+        // This extra level of indirection isn't necessary, but it's more
+        // convenient to use Arc::{increment,decrement}_strong_count below and
+        // the same functions don't exist for weak counts.
+        let callback_info = Arc::new(timer_ref);
+
+        unsafe extern "C-unwind" fn retain(info: *const c_void) -> *const c_void {
+            // SAFETY: The pointer was passed to CFRunLoopTimerContext.info below.
+            unsafe { Arc::increment_strong_count(info.cast::<Weak<Mutex<TimerState>>>()) };
+            info
+        }
+
+        unsafe extern "C-unwind" fn release(info: *const c_void) {
+            // SAFETY: The pointer was passed to CFRunLoopTimerContext.info below.
+            unsafe { Arc::decrement_strong_count(info.cast::<Weak<Mutex<TimerState>>>()) };
+        }
+
+        unsafe extern "C-unwind" fn timer_fire_callback(
+            _timer: *mut CFRunLoopTimer,
+            info: *mut c_void,
+        ) {
+            if info.is_null() {
+                return;
+            }
+
+            // SAFETY: The pointer was passed to CFRunLoopTimerContext.info below.
+            let timer_ref = unsafe { &*info.cast::<Weak<Mutex<TimerState>>>() };
+
+            let Some(timer) = timer_ref.upgrade() else { return };
+            let mut state = timer.lock().unwrap();
+            state.status = TimerStatus::Fired;
+            if let Some(waker) = state.waker.take() {
+                waker.wake();
+            }
+        }
+
+        // This is marked `mut` to match the signature of `CFRunLoopTimer::new`,
+        // but the information is copied, and not actually mutated.
+        let mut context = CFRunLoopTimerContext {
+            version: 0,
+            // This pointer is retained by CF on creation.
+            info: Arc::as_ptr(&callback_info) as *mut c_void,
+            retain: Some(retain),
+            release: Some(release),
+            copyDescription: None,
+        };
+
+        // SAFETY: The retain/release callbacks and info are thread-safe.
+        let cf_timer = unsafe {
+            CFRunLoopTimer::new(
+                kCFAllocatorDefault,
+                fire_date,
+                interval,
+                0, // flags - documentation says to pass 0 for future compatibility
+                0, // order
+                Some(timer_fire_callback),
+                &mut context,
+            )
+        }
+        .expect("Failed to create CFRunLoopTimer");
+
+        // Add timer to current run loop
+        let current_loop = CFRunLoop::current().expect("Failed to get current run loop");
+        current_loop.add_timer(Some(&cf_timer), unsafe { kCFRunLoopCommonModes });
+
+        if let Ok(mut state) = inner.lock() {
+            state.cf_timer = Some(cf_timer);
+        }
+
+        Timer { inner }
+    }
+
+    /// Sets the next time the timer will fire.
+    pub fn set_next_fire(&self, delay: Duration) {
+        let mut state = self.inner.lock().unwrap();
+        let Some(cf_timer) = state.cf_timer.as_mut() else {
+            return;
+        };
+        let fire_time = CFAbsoluteTimeGetCurrent() + delay.as_secs_f64();
+        cf_timer.set_next_fire_date(fire_time);
+    }
+
+    /// Cancels the timer, preventing it from firing.
+    ///
+    /// After calling this method, awaiting the timer will complete immediately
+    /// without the timer having fired. `next()` will return `None`.
+    pub fn cancel(&self) {
+        if let Ok(mut state) = self.inner.lock() {
+            if let Some(cf_timer) = state.cf_timer.take() {
+                cf_timer.invalidate();
+            }
+            state.status = TimerStatus::Cancelled;
+            if let Some(waker) = state.waker.take() {
+                waker.wake();
+            }
+        }
+    }
+
+    /// Convenience method to get the next timer event.
+    pub fn next(&mut self) -> impl Future<Output = Option<()>> {
+        tokio_stream::StreamExt::next(self)
+    }
+}
+
+impl Stream for Timer {
+    type Item = ();
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut state = self.inner.lock().unwrap();
+        match state.status {
+            TimerStatus::Cancelled => Poll::Ready(None),
+            TimerStatus::Fired => {
+                // Reset the fired state for repeating timers
+                state.status = TimerStatus::Pending;
+                Poll::Ready(Some(()))
+            }
+            TimerStatus::Pending => {
+                state.waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+}
+
+impl Future for Timer {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Poll until the timer fires or is cancelled.
+        self.poll_next(cx).map(|_| ())
+    }
+}
+
+impl Drop for Timer {
+    fn drop(&mut self) {
+        self.cancel();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sys::executor::Executor;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn timer_fires_after_delay() {
+        let start = Instant::now();
+        let delay = Duration::from_millis(50);
+
+        Executor::run(async move {
+            Timer::sleep(delay).await;
+        });
+
+        let elapsed = start.elapsed();
+        // Allow some tolerance; documentation allows sub-millisecond tweaks.
+        assert!(elapsed >= delay - Duration::from_millis(1));
+        // Useful for verifying units, but shouldn't run in CI:
+        // assert!(elapsed < delay + Duration::from_millis(20));
+    }
+
+    #[test]
+    fn timer_can_be_cancelled() {
+        let timer = Timer::sleep(Duration::from_secs(100));
+        timer.cancel();
+
+        let start = Instant::now();
+        Executor::run(async move {
+            timer.await;
+        });
+
+        // Should complete immediately since timer was cancelled
+        assert!(start.elapsed() < Duration::from_secs(45));
+    }
+
+    #[test]
+    fn multiple_timers_work() {
+        let start = Instant::now();
+
+        Executor::run(async move {
+            let timer1 = Timer::sleep(Duration::from_millis(30));
+            let timer2 = Timer::sleep(Duration::from_millis(60));
+
+            timer1.await;
+            let mid = start.elapsed();
+
+            timer2.await;
+            let end = start.elapsed();
+
+            assert!(mid >= Duration::from_millis(25));
+            assert!(end >= Duration::from_millis(55));
+            // Useful for verifying units, but shouldn't run in CI:
+            // assert!(mid < Duration::from_millis(50));
+            // assert!(end < Duration::from_millis(80));
+        });
+    }
+
+    #[test]
+    fn timer_thread_safety() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::thread;
+
+        // This test validates that our Arc<Mutex<TimerState>> approach is thread-safe
+        // by ensuring multiple threads can safely interact with timers
+
+        let timer_fired = Arc::new(AtomicBool::new(false));
+        let timer_fired_clone = Arc::clone(&timer_fired);
+
+        let handle = thread::spawn(move || {
+            Executor::run(async move {
+                let timer = Timer::sleep(Duration::from_millis(50));
+                timer.await;
+                timer_fired_clone.store(true, Ordering::Relaxed);
+            });
+        });
+
+        // Wait for completion
+        handle.join().unwrap();
+
+        // Timer should have fired
+        assert!(timer_fired.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn repeating_timer_works() {
+        let start = Instant::now();
+
+        Executor::run(async {
+            let mut timer = Timer::repeating(
+                Duration::from_millis(20), // initial delay
+                Duration::from_millis(10), // repeat interval
+            );
+
+            timer.next().await; // First fire (after initial delay)
+            let elapsed1 = start.elapsed();
+
+            timer.next().await; // Second fire (after repeat interval)
+            let elapsed2 = start.elapsed();
+
+            timer.next().await; // Third fire
+            let elapsed3 = start.elapsed();
+
+            // Verify timing
+            assert!(elapsed1 >= Duration::from_millis(20 - 1));
+            assert!(elapsed2 >= Duration::from_millis(30 - 1));
+            assert!(elapsed3 >= Duration::from_millis(40 - 1));
+        });
+    }
+}

--- a/src/sys/window_server.rs
+++ b/src/sys/window_server.rs
@@ -155,7 +155,7 @@ unsafe extern "C" {
     fn GetProcessForPID(pid: pid_t, psn: *mut ProcessSerialNumber) -> CGError;
 }
 
-/// Sets the given window as the key window of the window server.
+/// Set the key window of the window server and application.
 pub fn make_key_window(pid: pid_t, wsid: WindowServerId) -> Result<(), ()> {
     // See https://github.com/Hammerspoon/hammerspoon/issues/370#issuecomment-545545468.
     #[allow(non_upper_case_globals)]


### PR DESCRIPTION
This adds a RaiseManager actor to handle pending raise requests. The requests are handled in a queue to make sure the final state has the correct windows on top. However, raise requests within a request (that are not the final "focus" window) can be handled concurrently.